### PR TITLE
Fixed mousemove event listener

### DIFF
--- a/src/components/hs-dropdown/index.js
+++ b/src/components/hs-dropdown/index.js
@@ -98,8 +98,8 @@ class HSDropdown extends Component {
 
     document.addEventListener('mousemove', (e) => {
       const $targetEl = e.target;
+      if (!$targetEl) return;
       const $dropdownEl = $targetEl.closest(this.selector);
-      const $menuEl = $targetEl.closest('.hs-dropdown-menu');
 
       if ($dropdownEl) {
         const trigger = (window.getComputedStyle($dropdownEl).getPropertyValue('--trigger') || 'click').replace(

--- a/src/components/hs-tooltip/index.js
+++ b/src/components/hs-tooltip/index.js
@@ -26,6 +26,7 @@ class HSTooltip extends Component {
 
     document.addEventListener('mousemove', (e) => {
       const $targetEl = e.target;
+      if (!$targetEl) return;
       const $tooltipEl = $targetEl.closest(this.selector);
 
       if (


### PR DESCRIPTION
This is a very simple fix to the mousemove event listener. When developing on smaller screens, when the mouse is moved out of the viewport area, it cannot find the event target and hence throws error. Just adding a check to ensure that it's not null before finding the closest selector.