### PR TITLE
fix: #265 select plugin placeholder not cleared when default values l…

### DIFF
--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -351,7 +351,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			(this.value as string[]).forEach((val) => {
 				this.buildTagsItem(val);
 			});
-
+			(this.tagsInput as HTMLInputElement).placeholder = '';
 			(this.tagsInput as HTMLInputElement).readOnly = true;
 		}
 


### PR DESCRIPTION
To fix the issue of the placeholder not clearing when default values are loaded, `(this.tagsInput as HTMLInputElement).placeholder = '';` is added within the if (this.value) block. This line sets the placeholder attribute of the tagsInput element to an empty string, effectively clearing the placeholder text.