### PR TITLE
Fix: reset handler

### DIFF
--- a/src/plugins/stepper/index.ts
+++ b/src/plugins/stepper/index.ts
@@ -695,14 +695,14 @@ class HSStepper extends HSBasePlugin<{}> implements IStepper {
 
 		this.currentIndex = 1;
 
+		this.unsetCompleted();
+		this.isCompleted = false;
+
 		this.setCurrentNavItem();
 		this.setCurrentContentItem();
 		this.showFinishButton();
 		this.showCompleteStepButton();
 		this.checkForTheFirstStep();
-
-		this.unsetCompleted();
-		this.isCompleted = false;
 
 		this.fireEvent('reset', this.currentIndex);
 		dispatch('reset.hs.stepper', this.el, this.currentIndex);


### PR DESCRIPTION
Hello @olegpix,


**Problem**


I encounter an issue with the stepper component. When the reset button is clicked, other elements like navigation and buttons reset correctly, but the content of the final step is still displayed, as shown in the image below.

**Preline Documentation image**
![Screenshot 2024-06-02 183039](https://github.com/htmlstreamofficial/preline/assets/110020770/b9d56f3a-9ddf-4e62-9f6c-947f5e7330a2)

**Local project image**

![local](https://github.com/htmlstreamofficial/preline/assets/110020770/595bcb1a-d7ce-44cf-98c0-3311f19047be)

It appears that the issue is caused by the placement of the following code:
```
//  handleResetButtonClick()
this.setCurrentNavItem();
this.setCurrentContentItem();
this.showFinishButton();
this.showCompleteStepButton();
this.checkForTheFirstStep();

// This code
this.unsetCompleted();
this.isCompleted = false;
```

**Solution**

The problem is resolved by placing the following code above the other function calls:
```
this.unsetCompleted();
this.isCompleted = false;

this.setCurrentNavItem();
this.setCurrentContentItem();
this.showFinishButton();
this.showCompleteStepButton();
this.checkForTheFirstStep();
```

Moving `this.unsetCompleted();` and `this.isCompleted = false;` above the other function calls ensures that the content resets properly along with the navigation and buttons.

**Solved image**


https://github.com/htmlstreamofficial/preline/assets/110020770/454d7317-aa00-4109-9def-c45981899e5b

