### PR TITLE
fixes #252 fire change event when the tag close icon is clicked and item is removed

### DIFF
--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -364,6 +364,8 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			this.selectMultipleItems();
 
 			newItem.remove();
+			this.fireEvent('change', this.value);
+			dispatch('change.hs.select', this.el, this.value);
 		});
 
 		this.wrapper.append(newItem);


### PR DESCRIPTION
## Problem:
 
When the close icon on tag is clicked on the advanced select component, the change event is not fired but the item is removed.

## Changes:

Fire the change event once the item is removed.