### PR TITLE
feat: better auto init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"name": "preline",
 			"version": "2.4.1",
-			"license": "MIT",
+			"license": "Licensed under MIT and Preline UI Fair Use License",
 			"dependencies": {
 				"@popperjs/core": "^2.11.2"
 			},

--- a/src/plugins/accordion/index.ts
+++ b/src/plugins/accordion/index.ts
@@ -155,10 +155,10 @@ class HSAccordion
 			elInCollection.element.hide();
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsAccordionCollection) window.$hsAccordionCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('.hs-accordion:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/carousel/index.ts
+++ b/src/plugins/carousel/index.ts
@@ -297,10 +297,10 @@ class HSCarousel extends HSBasePlugin<ICarouselOptions> implements ICarousel {
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsCarouselCollection) window.$hsCarouselCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-carousel]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/collapse/index.ts
+++ b/src/plugins/collapse/index.ts
@@ -130,10 +130,10 @@ class HSCollapse extends HSBasePlugin<{}> implements ICollapse {
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsCollapseCollection) window.$hsCollapseCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('.hs-collapse-toggle:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/combobox/index.ts
+++ b/src/plugins/combobox/index.ts
@@ -848,10 +848,21 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 			: null;
 	}
 
-	static autoInit() {
-		if (!window.$hsComboBoxCollection) window.$hsComboBoxCollection = [];
+	static autoInit(target: HTMLElement | null = null) {
+		if (!window.$hsComboBoxCollection) {
+            window.$hsComboBoxCollection = [];
+            window.addEventListener('click', (evt) => {
+				const evtTarget = evt.target;
 
-		document
+				HSComboBox.closeCurrentlyOpened(evtTarget as HTMLElement);
+			});
+
+			document.addEventListener('keydown', (evt) =>
+				HSComboBox.accessibility(evt),
+			);
+        }
+
+		(target || document)
 			.querySelectorAll('[data-hs-combo-box]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (
@@ -865,18 +876,6 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 					new HSComboBox(el, options);
 				}
 			});
-
-		if (window.$hsComboBoxCollection) {
-			window.addEventListener('click', (evt) => {
-				const evtTarget = evt.target;
-
-				HSComboBox.closeCurrentlyOpened(evtTarget as HTMLElement);
-			});
-
-			document.addEventListener('keydown', (evt) =>
-				HSComboBox.accessibility(evt),
-			);
-		}
 	}
 
 	static close(target: HTMLElement | string) {

--- a/src/plugins/copy-markup/index.ts
+++ b/src/plugins/copy-markup/index.ts
@@ -139,10 +139,10 @@ class HSCopyMarkup
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsCopyMarkupCollection) window.$hsCopyMarkupCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-copy-markup]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/datatable/index.ts
+++ b/src/plugins/datatable/index.ts
@@ -411,10 +411,10 @@ class HSDataTable
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsDataTableCollection) window.$hsDataTableCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-datatable]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/dropdown/index.ts
+++ b/src/plugins/dropdown/index.ts
@@ -286,22 +286,10 @@ class HSDropdown
 			: null;
 	}
 
-	static autoInit() {
-		if (!window.$hsDropdownCollection) window.$hsDropdownCollection = [];
-
-		document
-			.querySelectorAll('.hs-dropdown:not(.--prevent-on-load-init)')
-			.forEach((el: IHTMLElementPopper) => {
-				if (
-					!window.$hsDropdownCollection.find(
-						(elC) => (elC?.element?.el as HTMLElement) === el,
-					)
-				)
-					new HSDropdown(el);
-			});
-
-		if (window.$hsDropdownCollection) {
-			document.addEventListener('keydown', (evt) =>
+	static autoInit(target: HTMLElement | null = null) {
+		if (!window.$hsDropdownCollection) {
+            window.$hsDropdownCollection = [];
+            document.addEventListener('keydown', (evt) =>
 				HSDropdown.accessibility(evt),
 			);
 
@@ -318,7 +306,18 @@ class HSDropdown
 					HSDropdown.closeCurrentlyOpened(null, false);
 				}
 			});
-		}
+        }
+
+		(target || document)
+			.querySelectorAll('.hs-dropdown:not(.--prevent-on-load-init)')
+			.forEach((el: IHTMLElementPopper) => {
+				if (
+					!window.$hsDropdownCollection.find(
+						(elC) => (elC?.element?.el as HTMLElement) === el,
+					)
+				)
+					new HSDropdown(el);
+			});
 	}
 
 	static open(target: HTMLElement) {

--- a/src/plugins/file-upload/index.ts
+++ b/src/plugins/file-upload/index.ts
@@ -333,10 +333,10 @@ class HSFileUpload
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsFileUploadCollection) window.$hsFileUploadCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-file-upload]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/input-number/index.ts
+++ b/src/plugins/input-number/index.ts
@@ -253,10 +253,10 @@ class HSInputNumber
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsInputNumberCollection) window.$hsInputNumberCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-input-number]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/overlay/index.ts
+++ b/src/plugins/overlay/index.ts
@@ -378,10 +378,15 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 			: null;
 	}
 
-	static autoInit() {
-		if (!window.$hsOverlayCollection) window.$hsOverlayCollection = [];
+	static autoInit(target: HTMLElement | null = null) {
+		if (!window.$hsOverlayCollection) {
+            window.$hsOverlayCollection = [];
+            document.addEventListener('keydown', (evt) =>
+				HSOverlay.accessibility(evt),
+			);
+        }
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-overlay]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (
@@ -391,12 +396,6 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 				)
 					new HSOverlay(el);
 			});
-
-		if (window.$hsOverlayCollection) {
-			document.addEventListener('keydown', (evt) =>
-				HSOverlay.accessibility(evt),
-			);
-		}
 	}
 
 	static open(target: HTMLElement) {

--- a/src/plugins/pin-input/index.ts
+++ b/src/plugins/pin-input/index.ts
@@ -165,10 +165,10 @@ class HSPinInput extends HSBasePlugin<IPinInputOptions> implements IPinInput {
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsPinInputCollection) window.$hsPinInputCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-pin-input]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/remove-element/index.ts
+++ b/src/plugins/remove-element/index.ts
@@ -56,11 +56,11 @@ class HSRemoveElement
 	}
 
 	// Static method
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsRemoveElementCollection)
 			window.$hsRemoveElementCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-remove-element]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/scrollspy/index.ts
+++ b/src/plugins/scrollspy/index.ts
@@ -161,10 +161,10 @@ class HSScrollspy extends HSBasePlugin<{}> implements IScrollspy {
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsScrollspyCollection) window.$hsScrollspyCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-scrollspy]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/search-by-json/index.ts
+++ b/src/plugins/search-by-json/index.ts
@@ -179,11 +179,11 @@ class HSSearchByJson
 		return elInCollection ? elInCollection.element : null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsSearchByJsonCollection)
 			window.$hsSearchByJsonCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-search-by-json]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLInputElement) => {
 				if (

--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -1099,10 +1099,21 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			: null;
 	}
 
-	static autoInit() {
-		if (!window.$hsSelectCollection) window.$hsSelectCollection = [];
+	static autoInit(target: HTMLElement | null = null) {
+		if (!window.$hsSelectCollection) {
+            window.$hsSelectCollection = [];
+            window.addEventListener('click', (evt) => {
+				const evtTarget = evt.target;
 
-		document
+				HSSelect.closeCurrentlyOpened(evtTarget as HTMLElement);
+			});
+
+			document.addEventListener('keydown', (evt) =>
+				HSSelect.accessibility(evt),
+			);
+        }
+
+		(target || document)
 			.querySelectorAll('[data-hs-select]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (
@@ -1116,18 +1127,6 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 					new HSSelect(el, options);
 				}
 			});
-
-		if (window.$hsSelectCollection) {
-			window.addEventListener('click', (evt) => {
-				const evtTarget = evt.target;
-
-				HSSelect.closeCurrentlyOpened(evtTarget as HTMLElement);
-			});
-
-			document.addEventListener('keydown', (evt) =>
-				HSSelect.accessibility(evt),
-			);
-		}
 	}
 
 	static open(target: HTMLElement | string) {
@@ -1153,7 +1152,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 		}
 	}
 
-	static closeCurrentlyOpened(evtTarget: HTMLElement | null = null) {
+	static closeCurrentlyOpened(evttarget: HTMLElement | null = null) {
 		if (!evtTarget.closest('.hs-select.active')) {
 			const currentlyOpened =
 				window.$hsSelectCollection.filter((el) => el.element.isOpened) || null;

--- a/src/plugins/stepper/index.ts
+++ b/src/plugins/stepper/index.ts
@@ -769,10 +769,10 @@ class HSStepper extends HSBasePlugin<{}> implements IStepper {
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsStepperCollection) window.$hsStepperCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-stepper]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/strong-password/index.ts
+++ b/src/plugins/strong-password/index.ts
@@ -327,11 +327,11 @@ class HSStrongPassword
 		return elInCollection ? elInCollection.element : null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsStrongPasswordCollection)
 			window.$hsStrongPasswordCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll(
 				'[data-hs-strong-password]:not(.--prevent-on-load-init)',
 			)

--- a/src/plugins/tabs/index.ts
+++ b/src/plugins/tabs/index.ts
@@ -108,10 +108,13 @@ class HSTabs extends HSBasePlugin<{}> implements ITabs {
 			: null;
 	}
 
-	static autoInit() {
-		if (!window.$hsTabsCollection) window.$hsTabsCollection = [];
+	static autoInit(target: HTMLElement | null = null) {
+		if (!window.$hsTabsCollection) {
+            window.$hsTabsCollection = [];
+            document.addEventListener('keydown', (evt) => HSTabs.accessibility(evt));
+        }
 
-		document
+		(target || document)
 			.querySelectorAll(
 				'[role="tablist"]:not(select):not(.--prevent-on-load-init)',
 			)
@@ -123,9 +126,6 @@ class HSTabs extends HSBasePlugin<{}> implements ITabs {
 				)
 					new HSTabs(el);
 			});
-
-		if (window.$hsTabsCollection)
-			document.addEventListener('keydown', (evt) => HSTabs.accessibility(evt));
 	}
 
 	static open(target: HTMLElement) {

--- a/src/plugins/theme-switch/index.ts
+++ b/src/plugins/theme-switch/index.ts
@@ -101,7 +101,7 @@ class HSThemeSwitch
 		return elInCollection ? elInCollection.element : null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsThemeSwitchCollection) window.$hsThemeSwitchCollection = [];
 
 		const toggleObserveSystemTheme = (el: HSThemeSwitch) => {
@@ -110,7 +110,7 @@ class HSThemeSwitch
 			else el.removeSystemThemeObserver();
 		};
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-theme-switch]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (
@@ -135,7 +135,7 @@ class HSThemeSwitch
 				}
 			});
 
-		document
+            (target || document)
 			.querySelectorAll(
 				'[data-hs-theme-click-value]:not(.--prevent-on-load-init)',
 			)

--- a/src/plugins/toggle-count/index.ts
+++ b/src/plugins/toggle-count/index.ts
@@ -104,10 +104,10 @@ class HSToggleCount
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsToggleCountCollection) window.$hsToggleCountCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll('[data-hs-toggle-count]:not(.--prevent-on-load-init)')
 			.forEach((el: HTMLElement) => {
 				if (

--- a/src/plugins/toggle-password/index.ts
+++ b/src/plugins/toggle-password/index.ts
@@ -160,11 +160,11 @@ class HSTogglePassword
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsTogglePasswordCollection)
 			window.$hsTogglePasswordCollection = [];
 
-		document
+		(target || document)
 			.querySelectorAll(
 				'[data-hs-toggle-password]:not(.--prevent-on-load-init)',
 			)

--- a/src/plugins/tooltip/index.ts
+++ b/src/plugins/tooltip/index.ts
@@ -183,10 +183,10 @@ class HSTooltip extends HSBasePlugin<{}> implements ITooltip {
 			: null;
 	}
 
-	static autoInit() {
+	static autoInit(target: HTMLElement | null = null) {
 		if (!window.$hsTooltipCollection) window.$hsTooltipCollection = [];
 
-		document.querySelectorAll('.hs-tooltip').forEach((el: HTMLElement) => {
+		(target || document).querySelectorAll('.hs-tooltip').forEach((el: HTMLElement) => {
 			if (
 				!window.$hsTooltipCollection.find(
 					(elC) => (elC?.element?.el as HTMLElement) === el,

--- a/src/spa/interfaces.ts
+++ b/src/spa/interfaces.ts
@@ -1,7 +1,7 @@
 export interface ISpaCollectionItem {
 	key: string;
 	fn: {
-		autoInit: () => void;
+		autoInit: (target: HTMLElement | null = null) => void;
 	};
 	collection: string;
 }

--- a/src/static/index.ts
+++ b/src/static/index.ts
@@ -62,14 +62,14 @@ declare global {
 const HSStaticMethods: IStaticMethods = {
 	getClassProperty,
 	afterTransition,
-	autoInit(collection: string | string[] = 'all') {
+	autoInit(collection: string | string[] = 'all', target: HTMLElement | null = null) {
 		if (collection === 'all') {
 			COLLECTIONS.forEach(({ fn }) => {
-				fn?.autoInit();
+				fn?.autoInit(target);
 			});
 		} else {
 			COLLECTIONS.forEach(({ key, fn }) => {
-				if (collection.includes(key)) fn?.autoInit();
+				if (collection.includes(key)) fn?.autoInit(target);
 			});
 		}
 	},

--- a/src/static/interfaces.ts
+++ b/src/static/interfaces.ts
@@ -1,6 +1,6 @@
 export interface IStaticMethods {
 	getClassProperty(el: HTMLElement, prop?: string, val?: string): string;
 	afterTransition(el: HTMLElement, cb: Function): void;
-	autoInit(collection?: string | string[]): void;
+	autoInit(collection?: string | string[], target: HTMLElement | null = null): void;
 	cleanCollection(collection?: string | string[]): void;
 }


### PR DESCRIPTION
This PR fixes a memory leak of autoInit() of several components.

In addition, autoInit() now allows to pass an html element, so that the autoInit() happens only on that element (and children) and not always on the whole document. This makes using autoInit() with small ajax partials more efficient.