### PR TITLE
fix: auto init memory leak

### DIFF
--- a/src/plugins/combobox/index.ts
+++ b/src/plugins/combobox/index.ts
@@ -849,7 +849,18 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 	}
 
 	static autoInit() {
-		if (!window.$hsComboBoxCollection) window.$hsComboBoxCollection = [];
+		if (!window.$hsComboBoxCollection) {
+            window.$hsComboBoxCollection = [];
+            window.addEventListener('click', (evt) => {
+				const evtTarget = evt.target;
+
+				HSComboBox.closeCurrentlyOpened(evtTarget as HTMLElement);
+			});
+
+			document.addEventListener('keydown', (evt) =>
+				HSComboBox.accessibility(evt),
+			);
+        }
 
 		document
 			.querySelectorAll('[data-hs-combo-box]:not(.--prevent-on-load-init)')
@@ -865,18 +876,6 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 					new HSComboBox(el, options);
 				}
 			});
-
-		if (window.$hsComboBoxCollection) {
-			window.addEventListener('click', (evt) => {
-				const evtTarget = evt.target;
-
-				HSComboBox.closeCurrentlyOpened(evtTarget as HTMLElement);
-			});
-
-			document.addEventListener('keydown', (evt) =>
-				HSComboBox.accessibility(evt),
-			);
-		}
 	}
 
 	static close(target: HTMLElement | string) {

--- a/src/plugins/combobox/index.ts
+++ b/src/plugins/combobox/index.ts
@@ -850,8 +850,8 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 
 	static autoInit() {
 		if (!window.$hsComboBoxCollection) {
-            window.$hsComboBoxCollection = [];
-            window.addEventListener('click', (evt) => {
+			window.$hsComboBoxCollection = [];
+			window.addEventListener('click', (evt) => {
 				const evtTarget = evt.target;
 
 				HSComboBox.closeCurrentlyOpened(evtTarget as HTMLElement);
@@ -860,7 +860,7 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 			document.addEventListener('keydown', (evt) =>
 				HSComboBox.accessibility(evt),
 			);
-        }
+		}
 
 		document
 			.querySelectorAll('[data-hs-combo-box]:not(.--prevent-on-load-init)')

--- a/src/plugins/dropdown/index.ts
+++ b/src/plugins/dropdown/index.ts
@@ -288,8 +288,8 @@ class HSDropdown
 
 	static autoInit() {
 		if (!window.$hsDropdownCollection) {
-            window.$hsDropdownCollection = [];
-            document.addEventListener('keydown', (evt) =>
+			window.$hsDropdownCollection = [];
+			document.addEventListener('keydown', (evt) =>
 				HSDropdown.accessibility(evt),
 			);
 

--- a/src/plugins/dropdown/index.ts
+++ b/src/plugins/dropdown/index.ts
@@ -309,7 +309,7 @@ class HSDropdown
         }
 
 		document
-            .querySelectorAll('.hs-dropdown:not(.--prevent-on-load-init)')
+			.querySelectorAll('.hs-dropdown:not(.--prevent-on-load-init)')
 			.forEach((el: IHTMLElementPopper) => {
 				if (
 					!window.$hsDropdownCollection.find(

--- a/src/plugins/dropdown/index.ts
+++ b/src/plugins/dropdown/index.ts
@@ -287,21 +287,9 @@ class HSDropdown
 	}
 
 	static autoInit() {
-		if (!window.$hsDropdownCollection) window.$hsDropdownCollection = [];
-
-		document
-			.querySelectorAll('.hs-dropdown:not(.--prevent-on-load-init)')
-			.forEach((el: IHTMLElementPopper) => {
-				if (
-					!window.$hsDropdownCollection.find(
-						(elC) => (elC?.element?.el as HTMLElement) === el,
-					)
-				)
-					new HSDropdown(el);
-			});
-
-		if (window.$hsDropdownCollection) {
-			document.addEventListener('keydown', (evt) =>
+		if (!window.$hsDropdownCollection) {
+            window.$hsDropdownCollection = [];
+            document.addEventListener('keydown', (evt) =>
 				HSDropdown.accessibility(evt),
 			);
 
@@ -318,7 +306,18 @@ class HSDropdown
 					HSDropdown.closeCurrentlyOpened(null, false);
 				}
 			});
-		}
+        }
+
+		document
+            .querySelectorAll('.hs-dropdown:not(.--prevent-on-load-init)')
+			.forEach((el: IHTMLElementPopper) => {
+				if (
+					!window.$hsDropdownCollection.find(
+						(elC) => (elC?.element?.el as HTMLElement) === el,
+					)
+				)
+					new HSDropdown(el);
+			});
 	}
 
 	static open(target: HTMLElement) {

--- a/src/plugins/overlay/index.ts
+++ b/src/plugins/overlay/index.ts
@@ -379,7 +379,12 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 	}
 
 	static autoInit() {
-		if (!window.$hsOverlayCollection) window.$hsOverlayCollection = [];
+		if (!window.$hsOverlayCollection) {
+            window.$hsOverlayCollection = [];
+            document.addEventListener('keydown', (evt) =>
+				HSOverlay.accessibility(evt),
+			);
+        }
 
 		document
 			.querySelectorAll('[data-hs-overlay]:not(.--prevent-on-load-init)')
@@ -391,12 +396,6 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 				)
 					new HSOverlay(el);
 			});
-
-		if (window.$hsOverlayCollection) {
-			document.addEventListener('keydown', (evt) =>
-				HSOverlay.accessibility(evt),
-			);
-		}
 	}
 
 	static open(target: HTMLElement) {

--- a/src/plugins/overlay/index.ts
+++ b/src/plugins/overlay/index.ts
@@ -380,11 +380,11 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 
 	static autoInit() {
 		if (!window.$hsOverlayCollection) {
-            window.$hsOverlayCollection = [];
-            document.addEventListener('keydown', (evt) =>
+			window.$hsOverlayCollection = [];
+			document.addEventListener('keydown', (evt) =>
 				HSOverlay.accessibility(evt),
 			);
-        }
+		}
 
 		document
 			.querySelectorAll('[data-hs-overlay]:not(.--prevent-on-load-init)')

--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -1101,8 +1101,8 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 
 	static autoInit() {
 		if (!window.$hsSelectCollection) {
-            window.$hsSelectCollection = [];
-            window.addEventListener('click', (evt) => {
+			window.$hsSelectCollection = [];
+			window.addEventListener('click', (evt) => {
 				const evtTarget = evt.target;
 
 				HSSelect.closeCurrentlyOpened(evtTarget as HTMLElement);
@@ -1111,7 +1111,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			document.addEventListener('keydown', (evt) =>
 				HSSelect.accessibility(evt),
 			);
-        }
+		}
 
 		document
 			.querySelectorAll('[data-hs-select]:not(.--prevent-on-load-init)')

--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -1100,7 +1100,18 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 	}
 
 	static autoInit() {
-		if (!window.$hsSelectCollection) window.$hsSelectCollection = [];
+		if (!window.$hsSelectCollection) {
+            window.$hsSelectCollection = [];
+            window.addEventListener('click', (evt) => {
+				const evtTarget = evt.target;
+
+				HSSelect.closeCurrentlyOpened(evtTarget as HTMLElement);
+			});
+
+			document.addEventListener('keydown', (evt) =>
+				HSSelect.accessibility(evt),
+			);
+        }
 
 		document
 			.querySelectorAll('[data-hs-select]:not(.--prevent-on-load-init)')
@@ -1116,18 +1127,6 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 					new HSSelect(el, options);
 				}
 			});
-
-		if (window.$hsSelectCollection) {
-			window.addEventListener('click', (evt) => {
-				const evtTarget = evt.target;
-
-				HSSelect.closeCurrentlyOpened(evtTarget as HTMLElement);
-			});
-
-			document.addEventListener('keydown', (evt) =>
-				HSSelect.accessibility(evt),
-			);
-		}
 	}
 
 	static open(target: HTMLElement | string) {

--- a/src/plugins/tabs/index.ts
+++ b/src/plugins/tabs/index.ts
@@ -110,9 +110,9 @@ class HSTabs extends HSBasePlugin<{}> implements ITabs {
 
 	static autoInit() {
 		if (!window.$hsTabsCollection) {
-            window.$hsTabsCollection = [];
-            document.addEventListener('keydown', (evt) => HSTabs.accessibility(evt));
-        }
+			window.$hsTabsCollection = [];
+			document.addEventListener('keydown', (evt) => HSTabs.accessibility(evt));
+		}
 
 		document
 			.querySelectorAll(

--- a/src/plugins/tabs/index.ts
+++ b/src/plugins/tabs/index.ts
@@ -109,7 +109,10 @@ class HSTabs extends HSBasePlugin<{}> implements ITabs {
 	}
 
 	static autoInit() {
-		if (!window.$hsTabsCollection) window.$hsTabsCollection = [];
+		if (!window.$hsTabsCollection) {
+            window.$hsTabsCollection = [];
+            document.addEventListener('keydown', (evt) => HSTabs.accessibility(evt));
+        }
 
 		document
 			.querySelectorAll(
@@ -123,9 +126,6 @@ class HSTabs extends HSBasePlugin<{}> implements ITabs {
 				)
 					new HSTabs(el);
 			});
-
-		if (window.$hsTabsCollection)
-			document.addEventListener('keydown', (evt) => HSTabs.accessibility(evt));
 	}
 
 	static open(target: HTMLElement) {


### PR DESCRIPTION
This PR fixes a memory leak in autoInit() of combobox, select, dropdown, overlay, tabs.

When using autoInit() repeatedly, e.g. when doing partial updates with ajax like in the docs https://preline.co/docs/preline-javascript.html, some components will repeatedly initialize global event listeners, even though the repeated ones are not needed.

This PR fixes that just by only registering the event listeners the first time an autoInit() is called.