### PR TITLE
fix: Stepper reset button

### DIFF
--- a/src/plugins/stepper/index.ts
+++ b/src/plugins/stepper/index.ts
@@ -752,7 +752,9 @@ class HSStepper extends HSBasePlugin<{}> implements IStepper {
 		this.unsetCompleted();
 		this.isCompleted = false;
 
+		this.showSkipButton();
 		this.setCurrentNavItem();
+		this.setCurrentContentItem();
 		this.showFinishButton();
 		this.showCompleteStepButton();
 		this.checkForTheFirstStep();


### PR DESCRIPTION
Hello @olegpix and @jahaganiev,

Now there are 2 issues with your stepper reset button 
1.  When reset the first content is not shown this issue started from v2.6
![Screenshot 2024-12-06 at 10 30 08 AM](https://github.com/user-attachments/assets/9d30519f-25df-4dff-b13e-7aa9fe728e6e)

This issue occurs because you have removed

![Screenshot 2024-12-06 at 10 30 54 AM](https://github.com/user-attachments/assets/caa0101f-de05-4482-9996-aba091323066)


2. when there is a skip button and we reset the skip button is not being built 
    
![Screenshot 2024-12-06 at 10 31 19 AM](https://github.com/user-attachments/assets/a63177a3-0389-4998-88fa-d00dd68baa67)

    
## Now this pull request solves both issues 


https://github.com/user-attachments/assets/784c6408-c45e-4f76-9a3c-abce648f697a


