### PR TITLE
Suggestion for Enhancing `select` Consistency with Popper.js Integration

### DIFF
--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -23,6 +23,8 @@ import {
 	IApiFieldMap,
 } from '../select/interfaces';
 
+import { createPopper } from '@popperjs/core';
+
 import HSBasePlugin from '../base-plugin';
 import { ICollectionItem } from '../../interfaces';
 
@@ -647,24 +649,27 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 	}
 
 	private buildPopper() {
-		if (typeof Popper !== 'undefined' && Popper.createPopper) {
+		if (typeof createPopper !== 'undefined') {
 			document.body.appendChild(this.dropdown);
 
-			this.popperInstance = Popper.createPopper(
-				this.mode === 'tags' ? this.wrapper : this.toggle,
-				this.dropdown,
-				{
-					placement: POSITIONS[this.dropdownPlacement] || 'bottom',
-					strategy: 'fixed',
-					modifiers: [
-						{
-							name: 'offset',
-							options: {
-								offset: [0, 5],
-							},
+			const referenceElement =
+				this.mode === 'tags' ? this.wrapper : this.toggle;
+
+			this.popperInstance = createPopper(referenceElement, this.dropdown, {
+				placement: POSITIONS[this.dropdownPlacement] || 'bottom',
+				strategy: 'fixed',
+				modifiers: [
+					{
+						name: 'offset',
+						options: {
+							offset: [0, 5],
 						},
-					],
-				},
+					},
+				],
+			});
+		} else {
+			console.error(
+				'Popper.js is not available. Ensure that @popperjs/core is properly bundled.',
 			);
 		}
 	}


### PR DESCRIPTION
Hello @olegpix,  

This is a suggestive pull request.  

In the new example for `select` where users can use `"dropdownScope": "window"`, they currently need to explicitly include Popper.js on their page. However, this step is unnecessary for `dropdown` and `tooltip`, as they already utilize Popper.js internally. 

![Screenshot 2024-12-06 at 12 11 06 PM](https://github.com/user-attachments/assets/e2a51c94-7444-4e54-a329-464fdc8309ff)

To ensure consistency across components and improve user experience, I propose integrating Popper.js with `select` internally, just like `dropdown` and `tooltip`. This change will eliminate the need for users to include Popper.js separately on their pages.  

#### Before Changes  
When Popper.js is not included in the page:  

![Screenshot 2024-12-06 at 11 34 33 AM](https://github.com/user-attachments/assets/de40fb46-487c-4762-a2eb-995277975bbf)

#### After Changes  
With updates to `select/index.ts`, Popper.js is used internally without requiring explicit inclusion:  

![Screenshot 2024-12-06 at 12 16 17 PM](https://github.com/user-attachments/assets/d547e1fe-9a0f-46f2-b444-4381b86a910f)


I believe this change improves consistency and simplifies implementation for users.
Thank you!  
