### PR TITLE
`setValue()` fails when tags mode is enabled on advanced selects.

### DIFF
--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -277,23 +277,37 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 
 	public setValue(val: string | string[]) {
 		this.value = val;
-
 		this.clearSelections();
 
 		if (Array.isArray(val)) {
-			this.toggleTextWrapper.innerHTML = this.value.length
-				? this.stringFromValue()
-				: this.placeholder;
-			this.unselectMultipleItems();
-			this.selectMultipleItems();
+			if (this.mode === 'tags') {
+				this.unselectMultipleItems();
+				this.selectMultipleItems();
+
+				this.selectedItems = [];
+
+				const existingTags = this.wrapper.querySelectorAll('[data-tag-value]');
+				existingTags.forEach((tag) => tag.remove());
+
+				this.setTagsItems();
+				this.reassignTagsInputPlaceholder(
+					this.value.length ? '' : this.placeholder,
+				);
+			} else {
+				this.toggleTextWrapper.innerHTML = this.value.length
+					? this.stringFromValue()
+					: this.placeholder;
+				this.unselectMultipleItems();
+				this.selectMultipleItems();
+			}
 		} else {
 			this.setToggleTitle();
-
 			if (this.toggle.querySelector('[data-icon]')) this.setToggleIcon();
 			if (this.toggle.querySelector('[data-title]')) this.setToggleTitle();
-
 			this.selectSingleItem();
 		}
+
+		this.triggerChangeEventForNativeSelect();
 	}
 
 	private init() {
@@ -561,7 +575,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 		const value = this.apiUrl
 			? (this.remoteOptions as (ISingleOption & IApiFieldMap)[]).find(
 				(el) => `${el[this.apiFieldsMap.val]}` === val || el[this.apiFieldsMap.title] === val,
-			)
+				)
 			: this.selectOptions.find((el: ISingleOption) => el.val === val);
 
 		return value;
@@ -1029,7 +1043,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 				parseInt(window.getComputedStyle(this.wrapper).paddingRight));
 
 		(this.tagsInput as HTMLInputElement).style.width = `${Math.min(newWidth, maxWidth) + 2
-			}px`;
+		}px`;
 	}
 
 	private adjustInputWidth() {
@@ -1305,11 +1319,11 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			const optionVal = el.getAttribute('data-title-value').toLocaleLowerCase();
 			const regexSafeVal = val
 				? val
-					.split('')
-					.map((char) => {
-						return char.match(/\w/) ? `${char}[\\W_]*` : '\\W*';
-					})
-					.join('')
+						.split('')
+						.map((char) => {
+							return char.match(/\w/) ? `${char}[\\W_]*` : '\\W*';
+						})
+						.join('')
 				: '';
 			const regex = new RegExp(regexSafeVal, 'i');
 			const directMatch = this.isSearchDirectMatch;
@@ -1317,7 +1331,7 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			const condition = val
 				? directMatch
 					? !cleanedOptionVal.toLowerCase().includes(val.toLowerCase()) ||
-					countLimit >= this.searchLimit
+						countLimit >= this.searchLimit
 					: !regex.test(cleanedOptionVal) || countLimit >= this.searchLimit
 				: !regex.test(cleanedOptionVal);
 
@@ -1720,8 +1734,8 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 
 			const preparedOptions = isArrowUp
 				? Array.from(
-					dropdown.querySelectorAll(':scope > *:not(.hidden)'),
-				).reverse()
+						dropdown.querySelectorAll(':scope > *:not(.hidden)'),
+					).reverse()
 				: Array.from(dropdown.querySelectorAll(':scope > *:not(.hidden)'));
 			const options = preparedOptions.filter(
 				(el: any) => !el.classList.contains('disabled'),
@@ -1752,8 +1766,8 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 
 			const preparedOptions = isArrowUp
 				? Array.from(
-					dropdown.querySelectorAll(':scope >  *:not(.hidden)'),
-				).reverse()
+						dropdown.querySelectorAll(':scope >  *:not(.hidden)'),
+					).reverse()
 				: Array.from(dropdown.querySelectorAll(':scope >  *:not(.hidden)'));
 			const options = preparedOptions.filter(
 				(el: any) => !el.classList.contains('disabled'),
@@ -1791,8 +1805,8 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 			const preparedOptions = isStart
 				? Array.from(dropdown.querySelectorAll(':scope >  *:not(.hidden)'))
 				: Array.from(
-					dropdown.querySelectorAll(':scope >  *:not(.hidden)'),
-				).reverse();
+						dropdown.querySelectorAll(':scope >  *:not(.hidden)'),
+					).reverse();
 			const options = preparedOptions.filter(
 				(el: any) => !el.classList.contains('disabled'),
 			);


### PR DESCRIPTION
Hello @olegpix,

**Issue: Console Errors with `setValue()` method https://github.com/htmlstreamofficial/preline/issues/444#issuecomment-2543915173**

When executing the example without applying the necessary fixes, I encounter console errors related to the `setValue()` method. You can view the error occurrence in the following video:

https://github.com/user-attachments/assets/2e442e14-eb12-4f1a-a803-385913e91f39

**Reason:**
The `setValue()` method does not handle cases where the select component has tags mode enabled. This omission results in the observed console errors.


**Resolution: Updated Select Plugin**

After updating the select plugin, the console errors are resolved. The successful implementation is demonstrated in the video below:

https://github.com/user-attachments/assets/70bf28cb-ba43-4ffd-8504-d1af81910506

