### PR TITLE
Fixes Clicking Spacebar in advance select search box  Closing the Dro…

### DIFF
--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -1713,10 +1713,6 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 					evt.preventDefault();
 					this.onEnter(evt);
 					break;
-				case 'Space':
-					evt.preventDefault();
-					this.onEnter(evt);
-					break;
 				default:
 					break;
 			}


### PR DESCRIPTION
### Description:
This fix addresses an issue #528 in the advanced select component where pressing the spacebar in the search input causes the dropdown to close unexpectedly. This behavior prevents users from entering multi-word search terms (e.g., "United Arab Emirates"). 

### Changes:
- Modified the dropdown behavior to ensure it remains open when typing a space, allowing users to continue entering multi-word search queries without interruption.

### Impact:
- Users will now be able to enter search terms with spaces, such as "United Arab Emirates," without the dropdown closing unexpectedly.