### PR TITLE
added missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
 			"name": "preline",
 			"version": "3.0.0",
 			"license": "Licensed under MIT and Preline UI Fair Use License",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.13",
+				"vanilla-calendar-pro": "^3.0.3"
+			},
 			"devDependencies": {
 				"@types/clipboard": "^2.0.7",
 				"@types/dropzone": "^5.7.8",
@@ -34,6 +38,31 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+			"integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.9"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.13",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+			"integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.9"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+			"integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.8",
@@ -1912,6 +1941,16 @@
 			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/vanilla-calendar-pro": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/vanilla-calendar-pro/-/vanilla-calendar-pro-3.0.3.tgz",
+			"integrity": "sha512-bfmeGFaDeakk/OrwgM+22qDiRvIx1Zu+GG3+E/sCPjaKwbJR7AsDyRBfJQzVHRw3eeavU8jQQTRSFt8EPIPOGw==",
+			"license": "MIT",
+			"funding": {
+				"type": "individual",
+				"url": "https://ko-fi.com/uvarov_frontend"
 			}
 		},
 		"node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
 		"ts-loader": "^9.5.1",
 		"typescript": "^5.5.3",
 		"webpack-cli": "^5.0.1"
+	},
+	"dependencies": {
+		"@floating-ui/dom": "^1.6.13",
+		"vanilla-calendar-pro": "^3.0.3"
 	}
 }


### PR DESCRIPTION
```js
import 'preline';
```
use this in js file

> tailwind@1.0.0 dev /Users/kzaman/Sites/tailwind-starter
> vite


  VITE v6.2.0  ready in 753 ms

  ➜  Local:   http://localhost:6500/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
✘ [ERROR] Could not resolve "@floating-ui/dom"

    node_modules/.pnpm/preline@3.0.0/node_modules/preline/src/plugins/tooltip/index.ts:9:67:
      9 │ import { type Strategy, computePosition, autoUpdate, offset } from '@floating-ui/dom';
        ╵                                                                    ~~~~~~~~~~~~~~~~~~

  You can mark the path "@floating-ui/dom" as external to exclude it from the bundle, which will
  remove this error and leave the unresolved path in the bundle.

✘ [ERROR] Could not resolve "vanilla-calendar-pro"

    node_modules/.pnpm/preline@3.0.0/node_modules/preline/src/plugins/datepicker/vanilla-datepicker-pro.ts:1:25:
      1 │ import { Calendar } from "vanilla-calendar-pro";
        ╵                          ~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "vanilla-calendar-pro" as external to exclude it from the bundle, which will
  remove this error and leave the unresolved path in the bundle.

✘ [ERROR] Could not resolve "@floating-ui/dom"

    node_modules/.pnpm/preline@3.0.0/node_modules/preline/src/plugins/dropdown/index.ts:29:7:
      29 │ } from '@floating-ui/dom';
         ╵        ~~~~~~~~~~~~~~~~~~

  You can mark the path "@floating-ui/dom" as external to exclude it from the bundle, which will
  remove this error and leave the unresolved path in the bundle. 