### PR TITLE
Comply with css spec - put @import at the top 

### DIFF
--- a/variants.css
+++ b/variants.css
@@ -1,26 +1,3 @@
-/* States */
-@custom-variant hs-success {
-
-  &.success {
-    @slot;
-  }
-
-  .success & {
-    @slot;
-  }
-}
-
-@custom-variant hs-error {
-
-  &.error {
-    @slot;
-  }
-
-  .error & {
-    @slot;
-  }
-}
-
 /* Preline */
 @import './src/plugins/dropdown/variants.css';
 @import './src/plugins/remove-element/variants.css';
@@ -45,6 +22,29 @@
 @import './src/plugins/file-upload/variants.css';
 @import './src/plugins/datepicker/variants.css';
 @import './src/plugins/theme-switch/variants.css';
+
+/* States */
+@custom-variant hs-success {
+
+  &.success {
+    @slot;
+  }
+
+  .success & {
+    @slot;
+  }
+}
+
+@custom-variant hs-error {
+
+  &.error {
+    @slot;
+  }
+
+  .error & {
+    @slot;
+  }
+}
 
 /* Apexcharts */
 @custom-variant hs-apexcharts-tooltip-dark {


### PR DESCRIPTION
variants.css was not following the css spec when it comes to `@import` rules. `@import` rules are required to be defined above any other declaration or else they get ignored.

https://drafts.csswg.org/css-cascade-5/#at-import

In my case i was using PostCSS to inline CSS imports using postcss-import. Because of the incorrect declaration of the `@import` statements, tailwind variants were missing.