### PR TITLE
Append to existing className instead of overwriting

### DIFF
--- a/src/plugins/combobox/index.ts
+++ b/src/plugins/combobox/index.ts
@@ -618,8 +618,14 @@ class HSComboBox extends HSBasePlugin<IComboBoxOptions> implements IComboBox {
 						el.getAttribute("data-hs-combo-box-output-item-attr"),
 					);
 
-					attributes.forEach((attr: IComboBoxItemAttr) => {
-						el.setAttribute(attr.attr, item[attr.valueFrom]);
+					 attributes.forEach((attr: IComboBoxItemAttr) => {
+						let value: string = item[attr.valueFrom]
+
+						if (attr.attr === 'class' && el.className) {
+							el.className = `${el.className} ${value}`.trim()
+						} else {
+							el.setAttribute(attr.attr, value)
+						}
 					});
 				});
 			newItem.setAttribute("tabIndex", `${index}`);


### PR DESCRIPTION
**What Changed:**

* Updated logic to handle the `class` attribute separately.
* Appends the new class value to `el.className` instead of overwriting it.

**Why:**

* Prevents loss of existing CSS classes when dynamically setting attributes.
* Ensures that additional classes from data items are added without removing pre-existing ones.

**Impact:**

* Improves UI consistency and avoids unintended style overrides when multiple class values are applied.

