### PR TITLE
Fixed image checking for icons

### DIFF
--- a/src/plugins/select/index.ts
+++ b/src/plugins/select/index.ts
@@ -507,19 +507,20 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 				this.apiUrl && this.apiIconTag
 					? this.apiIconTag || ""
 					: item?.options?.icon || "",
-			) as HTMLImageElement;
+			);
 			if (
 				this.value &&
 				this.apiUrl &&
 				this.apiIconTag &&
-				item[this.apiFieldsMap.icon]
+				item[this.apiFieldsMap.icon] &&
+				img instanceof HTMLImageElement
 			) {
 				img.src = (item[this.apiFieldsMap.icon] as string) || "";
 			}
 
 			icon.append(img);
 
-			if (!img?.src) icon.classList.add("hidden");
+			if (!img) icon.classList.add("hidden");
 			else icon.classList.remove("hidden");
 		}
 	}


### PR DESCRIPTION
**What Changed:** 
Added check for HTMLImageElement type compliance. And the check for the presence of the src property has been removed

**Why:**
There was no way to set svg as an icon as it is stated on the documentation page
https://preline.co/docs/advanced-select.html#custom-template-with-icons