### PR TITLE
The nullish coalescing operator (`??`) is being used incorrectly:

### DIFF
--- a/src/plugins/datatable/index.ts
+++ b/src/plugins/datatable/index.ts
@@ -124,9 +124,7 @@ class HSDataTable
 				null;
 		if (this.concatOptions?.rowSelectingOptions)
 			this.rowSelectingIndividual =
-				this.concatOptions?.rowSelectingOptions?.individualSelector ??
-				'[data-hs-datatable-row-selecting-individual]' ??
-				null;
+				this.concatOptions?.rowSelectingOptions?.individualSelector ?? '[data-hs-datatable-row-selecting-individual]'
 
 		if (this.pageEntitiesList.length) this.concatOptions.pageLength = parseInt(this.pageEntitiesList[0].value);
 


### PR DESCRIPTION
Hello @jahaganiev,

```js
this.concatOptions?.rowSelectingOptions?.individualSelector ?? '[data-hs-datatable-row-selecting-individual]' ?? null;
```

The issue is with the `?? null` part at the end. The nullish coalescing operator (`??`) only evaluates the right side if the left side is `null` or `undefined`. So, if `this.concatOptions?.rowSelectingOptions?.individualSelector` is `null` or `undefined`, it will use `'[data-hs-datatable-row-selecting-individual]'`. But, if that value is anything other than `null` or `undefined` (even an empty string, false, or zero), it will use that value and **ignore the `?? null` part**.

This makes the `?? null` redundant because you're already using `??` to check for `null` or `undefined`, so there's no need to check for `null` again explicitly.

### Correct Version:

The `?? null` should be removed since it's unnecessary:

```js
this.rowSelectingIndividual =
    this.concatOptions?.rowSelectingOptions?.individualSelector ??
    '[data-hs-datatable-row-selecting-individual]';
```

### Explanation:

* `this.concatOptions?.rowSelectingOptions?.individualSelector` is checked first. If it's `null` or `undefined`, then it will fall back to `'[data-hs-datatable-row-selecting-individual]'`.
* If `this.concatOptions?.rowSelectingOptions?.individualSelector` is a valid value (not `null` or `undefined`), it will be used directly.

This way, It will simplify the expression while maintaining its intended behavior.