### PR TITLE
fix(overlay): data-hs-overlay-keyboard not working

### DIFF
--- a/src/plugins/overlay/index.ts
+++ b/src/plugins/overlay/index.ts
@@ -783,7 +783,7 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 						if (!this.isOpened()) this.open();
 					},
 					onEsc: () => {
-						if (this.isOpened()) {
+						if (this.isOpened()  && this.hasAbilityToCloseOnBackdropClick) {
 							this.close();
 						}
 					},
@@ -837,7 +837,7 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 						if (!this.isOpened()) this.open();
 					},
 					onEsc: () => {
-						if (this.isOpened()) {
+						if (this.isOpened() && this.hasAbilityToCloseOnBackdropClick) {
 							this.close();
 						}
 					},


### PR DESCRIPTION
Hello @jahaganiev,

This PR resolves an issue where modals closed upon pressing ESC, despite `data-hs-overlay-keyboard="false"` being set.

The ESC key is now properly ignored when this attribute is used.
