### PR TITLE
Add Prettier cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ jspm_packages/
 # Optional eslint cache
 .eslintcache
 
+# Optional prettier cache
+/.prettier-cache
+
 # Optional REPL history
 .node_repl_history
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"watch:mjs": "webpack --config webpack.config.mjs.js --watch",
 		"build": "webpack --config webpack.config.js",
 		"build:mjs": "webpack --config webpack.config.mjs.js",
-		"pretty": "prettier --write \"./**/*.{js,jsx,ts,tsx,json}\"",
+		"pretty": "prettier --write --cache \"./**/*.{js,jsx,ts,tsx,json}\"",
 		"generate-dts": "dts-bundle-generator --config dts-config.js"
 	},
 	"dependencies": {


### PR DESCRIPTION
I find the .gitignore file has an optional eslint cache, not the eslint command, but has pretty. I wish maybe the pretty command should cache.