### PR TITLE
Fix get body current scrollbar size overlay

### DIFF
--- a/src/plugins/overlay/index.ts
+++ b/src/plugins/overlay/index.ts
@@ -395,16 +395,10 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 		else input.focus();
 	}
 
-	private getScrollbarSize() {
-		let div = document.createElement("div");
-		div.style.overflow = "scroll";
-		div.style.width = "100px";
-		div.style.height = "100px";
-		document.body.appendChild(div);
-
-		let scrollbarSize = div.offsetWidth - div.clientWidth;
-
-		document.body.removeChild(div);
+	private getBodyCurrentScrollbarSize() {
+		const bodyWidth = parseFloat(getComputedStyle(document.body).width);
+		let scrollbarSize = window.innerWidth - bodyWidth;
+		scrollbarSize = Math.max(scrollbarSize, 0);
 
 		return scrollbarSize;
 	}
@@ -503,10 +497,10 @@ class HSOverlay extends HSBasePlugin<{}> implements IOverlay {
 		}
 
 		if (disabledScroll) {
-			document.body.style.overflow = "hidden";
 			if (this.emulateScrollbarSpace) {
-				document.body.style.paddingRight = `${this.getScrollbarSize()}px`;
+				document.body.style.paddingRight = `${this.getBodyCurrentScrollbarSize()}px`;
 			}
+			document.body.style.overflow = "hidden";
 		}
 
 		this.buildBackdrop();


### PR DESCRIPTION
**Emulate scrollbar feature in overlay plugin**

The current method getScrollbarSize in overlay plugin does not work properly. It produce layout shift:
1. On phone, overlay plugin adds padding right to the body
2. On PC when the body does not have overflow content, the plugin still add padding right the body

**Desire result**
1. Do not add body padding right on phone
2. Do not add body padding right when body does not have overlay content

**Fix**

Calculate the scollbar size before setting body overflow hidden when open overlay
1. bodyWidth = getComputedStyle(document.body).width;
2. scrollbarSize = window.innerWidth - bodyWidth