### PR TITLE
fix(select): allow relative URLs for advanced select apiUrl

### DIFF
--- a/src/plugins/select/core.ts
+++ b/src/plugins/select/core.ts
@@ -1610,7 +1610,13 @@ class HSSelect extends HSBasePlugin<ISelectOptions> implements ISelect {
 
 	private async apiRequest(val = '', signal?: AbortSignal): Promise<any> {
 		try {
-			const url = new URL(this.apiUrl);
+			let url;
+			try {
+				url = new URL(this.apiUrl, window.location.origin);
+			} catch {
+				console.error('Invalid API URL:', this.apiUrl);
+				return null;
+			}
 			const queryParams = new URLSearchParams(this.apiQuery ?? '');
 			const options = this.apiOptions ?? {};
 			const tempOptions = { ...(options as any) } as RequestInit;


### PR DESCRIPTION
This tries to fix #761 and allow relative URLs for the advanced select element's `apiUrl` config property.

### Changes

Instead of just trying to construct the fetch URL with `new URL(this.apiUrl)`, this adds the second parameter to the `URL()` constructor:

```
url = new URL(this.apiUrl, window.location.origin);
```

If `apiUrl` is a full URL, this addition does nothing; the `URL()` constructor ignores it in cases where the first parameter is not a relative URL. But if `apiUrl` **is** a relative URL, then the second parameter provides the base to the final fetch URL.

This PR also wraps the attempt to construct the fetch URL in its own `try`/`catch` block, so that a console error can be emitted specifically for any failures in the construction.